### PR TITLE
sendNotification CA fix

### DIFF
--- a/src/use_case/send_notification/NotificationInteractor.java
+++ b/src/use_case/send_notification/NotificationInteractor.java
@@ -90,6 +90,10 @@ public class NotificationInteractor implements NotificationInputBoundary {
             NotificationOutputData notificationOutputData = new NotificationOutputData(gptQuery[1] + gptResponse);
             notificationPresenter.prepareNotificationView(notificationOutputData);
         }
+        else {
+            NotificationOutputData notificationOutputData = new NotificationOutputData(null);
+            notificationPresenter.prepareNotificationView(notificationOutputData);
+        }
 
 
 

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -32,6 +32,7 @@ public class DashboardView extends JPanel implements PropertyChangeListener {
     private JPanel dashboardPanel;
     private ArrayList<ProjectData> projectsList;
     private boolean fromLogin = true;
+    private boolean expectingNotification = false;
     private final ScheduledExecutorService schedule = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> scheduledFuture = null;
     private final AddProjectController addProjectController;
@@ -99,6 +100,7 @@ public class DashboardView extends JPanel implements PropertyChangeListener {
                 if (e.getSource() == toggleNotifications) {
                     // If notifications are turned off, start them up again using scheduleAtFixedRate
                     if (scheduledFuture == null) {
+                        expectingNotification = true;
                         Runnable sendNotification = () -> notificationController.execute(LocalDate.now(), dashboardViewModel.getState().getUsername());
                         scheduledFuture = schedule.scheduleAtFixedRate(sendNotification, 0, 24, TimeUnit.HOURS);
                         toggleNotifications.setText("Notifications Off");
@@ -470,12 +472,15 @@ public class DashboardView extends JPanel implements PropertyChangeListener {
             JOptionPane.showMessageDialog(this, state.getAddProjectError());
         }
         // ***Displays JOptionPane if there is a notification to be displayed.
-        if (state.getNotificationMessage() != null) {
-            JOptionPane.showMessageDialog(this, state.getNotificationMessage());
-            state.setNotificationMessage(null);
+        if (expectingNotification) {
+            expectingNotification = false;
+            if (state.getNotificationMessage() != null) {
+                JOptionPane.showMessageDialog(this, state.getNotificationMessage());
+            }
         }
         if (fromLogin) {
             fromLogin = false;
+            expectingNotification = true;
             Runnable sendNotification = () -> notificationController.execute(LocalDate.now(), dashboardViewModel.getState().getUsername());
             scheduledFuture = schedule.scheduleAtFixedRate(sendNotification, 0, 24, TimeUnit.HOURS);
         }


### PR DESCRIPTION
Fixed something small so that sendNotification aligns more with CA and dependency inversion. 

Added an expectingNotification attribute to DashboardView, so that it knows when fireProperty change is called that a notification should be displayed. Note that with this, it is possible with, precise clicking in the time between when the controller is called and the api returns, to skip the notification message, but it is very unlikely with normal use.